### PR TITLE
Delete merge conflict from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
 * **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html](https://github.com/Tjatse/ansi-html/blob/99ec49e431c70af6275b3c4e00c7be34be51753c/README.md#set-colors) package.
 * **overlayStyles** - An object to let you override or add new inline styles to the client overlay div.
-<<<<<<< HEAD
 * **overlayWarnings** - Set to `true` to enable client overlay on warnings in addition to errors.
-=======
->>>>>>> 43c3a0e... Update README.md
 
 > Note:
 > Since the `ansiColors` and `overlayStyles` options are passed via query string, you'll need to uri encode your stringified options like below:


### PR DESCRIPTION
It looks like [this commit](https://github.com/webpack-contrib/webpack-hot-middleware/commit/33bb607ed50d92aa9974c6085dc895e45ed8bc3e#diff-04c6e90faac2675aa89e2176d2eec7d8) added some merge resolution text to the readme, and this PR removes it. 