### PR TITLE
ci(circle): Pick up latest config from defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 unit_tests: &unit_tests
   steps:
     - checkout
-    - setup_remote_docker
     - restore_cache:
         key: dependency-cache-{{ checksum "package-lock.json" }}
     - run:
@@ -13,7 +12,6 @@ unit_tests: &unit_tests
 canary_tests: &canary_tests
   steps:
     - checkout
-    - setup_remote_docker
     - restore_cache:
         key: dependency-cache-{{ checksum "package-lock.json" }}
     - run:
@@ -24,7 +22,7 @@ canary_tests: &canary_tests
         command: npm i --no-save webpack@next
     - run:
         name: Run unit tests.
-        command: npm run ci:test
+        command: if [[ $(compver --name webpack --gte next --lt latest) < 1 ]] ; then printf "Next is older than Latest - Skipping Canary Suite"; else npm run ci:test ; fi
 
 version: 2
 jobs:
@@ -33,7 +31,6 @@ jobs:
       - image: webpackcontrib/circleci-node-base:latest
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
@@ -49,7 +46,6 @@ jobs:
       - image: webpackcontrib/circleci-node8:latest
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
@@ -79,7 +75,6 @@ jobs:
       - image: webpackcontrib/circleci-node-base:latest
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
@@ -92,14 +87,13 @@ jobs:
           name: Run NSP Security Check.
           command: npm run security
       # - run:
-      #     name: Validate Commit Messages
-      #     command: npm run ci:lint:commits
+      #    name: Validate Commit Messages
+      #    command: npm run ci:lint:commits
   publish:
     docker:
       - image: webpackcontrib/circleci-node-base:latest
     steps:
       - checkout
-      - setup_remote_docker
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
@@ -154,6 +148,7 @@ workflows:
       - publish:
           requires:
             - node8-latest
+            - node8-canary
             - node9-latest
           filters:
             branches:


### PR DESCRIPTION
  - Removes `setup_remote_docker`
  - Compares the next & latest dist-tag for Webpack & executes the Canary tests suite ( or doesn't )