### PR TITLE
Fixes issue with the overlay not closing when warnings are off

### DIFF
--- a/client.js
+++ b/client.js
@@ -205,10 +205,16 @@ function createReporter() {
       if (options.warn) {
         log(type, obj);
       }
-      if (overlay && (options.overlayWarnings || type !== 'warnings')) {
+      if (
+        overlay &&
+        (
+          (options.overlayWarnings && type === 'warnings') || type === 'errors'
+        )
+      ) {
         overlay.showProblems(type, obj[type]);
         return false;
       }
+      if (overlay) overlay.clear();
       return true;
     },
     success: function() {


### PR DESCRIPTION
## Condition:
User has switched off warnings. There are some warnings in the code.

## Expected Behaviour: 
When error triggers in the code, overlay should show up. When the error is fixed, overlay should hide. 

## Current Behavior:
If you introduce an error, overlay shows up. But if you fix the error, the overlay still remains. 

Debugging this issue, the cause came out to be this line of code. Please review this PR and help me fix this bug :)