### PR TITLE
feat(client): provide option for disabling console warn messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **overlay** - Set to `false` to disable the DOM-based client-side overlay.
 * **reload** - Set to `true` to auto-reload the page when webpack gets stuck.
 * **noInfo** - Set to `true` to disable informational console logging.
+* **noWarn** - Set to `true` to disable warning console logging.
 * **quiet** - Set to `true` to disable all console logging.
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function

--- a/client.js
+++ b/client.js
@@ -49,6 +49,9 @@ function setOverrides(overrides) {
   if (overrides.noInfo && overrides.noInfo !== 'false') {
     options.log = false;
   }
+  if (overrides.noWarn && overrides.noWarn !== 'false') {
+    options.warn = false;
+  }
   if (overrides.name) {
     options.name = overrides.name;
   }


### PR DESCRIPTION
Add noWarn client parameter.

resolves #319

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Add support for disabling console.warn messages on the client.

Resolves https://github.com/webpack-contrib/webpack-hot-middleware/issues/319

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info