### PR TITLE
Support HTTP/2

### DIFF
--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -183,6 +183,16 @@ describe("middleware", function() {
           }
         });
     });
+    // Express HTTP/2 support is in progress: https://github.com/expressjs/express/pull/3390
+    it("should not contain `conntection: keep-alive` header for HTTP/2 request");
+    it("should contain `conntection: keep-alive` header for HTTP/1 request", function(done) {
+      request('/__webpack_hmr')
+        .end(function(err, res) {
+          if (err) return done(err);			
+          assert.equal(res.headers['connection'], 'keep-alive');
+          done();
+        });
+    });
   });
 
   beforeEach(function() {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
webpack-hot-middleware must to support HTTP/2 out of the box.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
Nope.

### Additional Info

It's impossible to cover with tests HTTP/2 mode right now because Express HTTP/2 support is in progress: https://github.com/expressjs/express/pull/3390
