### PR TITLE
Performance improvement

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -91,15 +91,29 @@ function createEventStream(heartbeat) {
 }
 
 function publishStats(action, statsResult, eventStream, log) {
+  var stats = statsResult.toJson({
+    all: false,
+    children: true,
+    modules: true,
+    timings: true,
+    hash: true
+  });
   // For multi-compiler, stats will be an object with a 'children' array of stats
-  var bundles = extractBundles(statsResult.toJson({ errorDetails: false }));
+  var bundles = extractBundles(stats);
   bundles.forEach(function(stats) {
+    var name = stats.name || "";
+
+    // Fallback to compilation name in case of 1 bundle
+    if (bundles.length === 1 && !name) {
+      name = statsResult.compilation.name || "";
+    }
+
     if (log) {
-      log("webpack built " + (stats.name ? stats.name + " " : "") +
+      log("webpack built " + (name ? name + " " : "") +
         stats.hash + " in " + stats.time + "ms");
     }
     eventStream.publish({
-      name: stats.name,
+      name: name,
       action: action,
       time: stats.time,
       hash: stats.hash,

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -136,6 +136,24 @@ describe("middleware", function() {
           done();
         });
     });
+    it("should fallback to the compilation name if no stats name is provided and there is one stats object", function(done) {
+      compiler.emit("done", stats({
+        time: 100,
+        hash: "deadbeeffeddad",
+        warnings: false,
+        errors: false,
+        modules: []
+      }));
+
+      request('/__webpack_hmr')
+        .end(function(err, res) {
+          if (err) return done(err);
+
+          var event = JSON.parse(res.events[0].substring(5));
+          assert.equal(event.name, "compilation");
+          done();
+        });
+    });
     it("should have tests on the payload of bundle complete");
     it("should notify all clients", function(done) {
       request('/__webpack_hmr')
@@ -188,7 +206,7 @@ describe("middleware", function() {
     it("should contain `connection: keep-alive` header for HTTP/1 request", function(done) {
       request('/__webpack_hmr')
         .end(function(err, res) {
-          if (err) return done(err);			
+          if (err) return done(err);
           assert.equal(res.headers['connection'], 'keep-alive');
           done();
         });
@@ -242,6 +260,9 @@ describe("middleware", function() {
   }
   function stats(data) {
     return {
+      compilation: {
+        name: 'compilation'
+      },
       toJson: function() {
         return data;
       }


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This is related to a PR I opened [here](https://github.com/60frames/webpack-hot-server-middleware/pull/82). I'm currently upgrading a project to Webpack 4 and I'm not sure if the `toJson()` call got heavier but it's a pretty expensive call and probably always has been somewhat. Enough so that my muti-compiler setup can run out of memory when it's called without explicitly setting the options. This updates the the `toJson()` call to only request the stats necessary needed for the publish call. 

This also falls back to logging the compilation name when there's no `stat.name` available.

### Breaking Changes

No breaking changes.
