### PR TITLE
Fixing pipe evaluation inside string concatenation for error output a…

### DIFF
--- a/process-update.js
+++ b/process-update.js
@@ -100,7 +100,7 @@ module.exports = function(hash, moduleMap, options) {
           "See " + hmrDocsUrl + " for more details."
         );
         unacceptedModules.forEach(function(moduleId) {
-          console.warn("[HMR]  - " + moduleMap[moduleId] || moduleId);
+          console.warn("[HMR]  - " + (moduleMap[moduleId] || moduleId));
         });
       }
       performReload();
@@ -113,7 +113,7 @@ module.exports = function(hash, moduleMap, options) {
       } else {
         console.log("[HMR] Updated modules:");
         renewedModules.forEach(function(moduleId) {
-          console.log("[HMR]  - " + moduleMap[moduleId] || moduleId);
+          console.log("[HMR]  - " + (moduleMap[moduleId] || moduleId));
         });
       }
 
@@ -127,13 +127,13 @@ module.exports = function(hash, moduleMap, options) {
     if (module.hot.status() in failureStatuses) {
       if (options.warn) {
         console.warn("[HMR] Cannot check for update (Full reload needed)");
-        console.warn("[HMR] " + err.stack || err.message);
+        console.warn("[HMR] " + (err.stack || err.message));
       }
       performReload();
       return;
     }
     if (options.warn) {
-      console.warn("[HMR] Update check failed: " + err.stack || err.message);
+      console.warn("[HMR] Update check failed: " + (err.stack || err.message));
     }
   }
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Proper fix for logging of updated modules and update check failed

### Additional Info
I'm sorry for making a rookie mistake. Also thanks for the quick release @glenjamin ! Now back to what was wrong.
I saw this line and subconsciously thought that such a simple fix has to work so I replicated the same style to my fix
```
console.warn("[HMR] Update check failed: " + err.stack || err.message);
```
To my surprise this gets actually evaluated like
```
'foo ' + undefined || 'bar'
// "foo undefined"
// instead of
// "foo bar"
```
As concatenation has precedence over logical operator evaluation
The fix was to simply use parentheses
```
'foo ' + (undefined || 'bar')
// "foo bar"
```
I fixed the other incorrect log statements as well.
