### PR TITLE
fix iframe use window top

### DIFF
--- a/client.js
+++ b/client.js
@@ -117,15 +117,19 @@ function EventSourceWrapper() {
 }
 
 function getEventSourceWrapper() {
-  if (!window.__whmEventSourceWrapper) {
-    window.__whmEventSourceWrapper = {};
+  var top = window;
+  if (window.self !== window.top) {
+    top = window.top;
   }
-  if (!window.__whmEventSourceWrapper[options.path]) {
+  if (!top.__whmEventSourceWrapper) {
+    top.__whmEventSourceWrapper = {};
+  }
+  if (!top.__whmEventSourceWrapper[options.path]) {
     // cache the wrapper for other entries loaded on
     // the same page with the same options.path
-    window.__whmEventSourceWrapper[options.path] = EventSourceWrapper();
+    top.__whmEventSourceWrapper[options.path] = EventSourceWrapper();
   }
-  return window.__whmEventSourceWrapper[options.path];
+  return top.__whmEventSourceWrapper[options.path];
 }
 
 function connect() {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

When using iframes HMR was initializing inside each iframe, this way intead we use the parent instance of `window.__whmEventSourceWrapper` so you have no duplicate listeners and no limit on how many iframes you can have before the HMR hungs up with too many calls.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None

### Additional Info
