### PR TITLE
improved client overlay style

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -4,8 +4,8 @@ var clientOverlay = document.createElement('div');
 clientOverlay.id = 'webpack-hot-middleware-clientOverlay';
 var styles = {
   background: 'rgba(0,0,0,0.85)',
-  color: '#E8E8E8',
-  lineHeight: '1.2',
+  color: '#e8e8e8',
+  lineHeight: '1.6',
   whiteSpace: 'pre',
   fontFamily: 'Menlo, Consolas, monospace',
   fontSize: '13px',
@@ -25,14 +25,14 @@ var ansiHTML = require('ansi-html');
 var colors = {
   reset: ['transparent', 'transparent'],
   black: '181818',
-  red: 'E36049',
-  green: 'B3CB74',
-  yellow: 'FFD080',
-  blue: '7CAFC2',
-  magenta: '7FACCA',
-  cyan: 'C3C2EF',
-  lightgrey: 'EBE7E3',
-  darkgrey: '6D7891',
+  red: 'ff3348',
+  green: '3fff4f',
+  yellow: 'ffd30e',
+  blue: '169be0',
+  magenta: 'f840b7',
+  cyan: '0ad8e9',
+  lightgrey: 'ebe7e3',
+  darkgrey: '6d7891',
 };
 
 var Entities = require('html-entities').AllHtmlEntities;
@@ -67,7 +67,7 @@ function problemType(type) {
   return (
     '<span style="background-color:#' +
     color +
-    '; color:#fff; padding:2px 4px; border-radius: 2px">' +
+    '; color:#000000; padding:3px 6px; border-radius: 4px;">' +
     type.slice(0, -1).toUpperCase() +
     '</span>'
   );


### PR DESCRIPTION
This PR contains is to fix #359.

### Motivation

The style of the client overlay is slightly change for better readability.

### Breaking Changes

This PR doesn't introduce breaking changes

### Additional Info

Here are some before after screenshot of the client overlay.

**WARNING**
_before_
<img width="735" alt="before1" src="https://user-images.githubusercontent.com/10623367/57737057-876b8800-76aa-11e9-94ca-dfe2767ae007.png">
_after_
<img width="735" alt="after1" src="https://user-images.githubusercontent.com/10623367/57737063-8d616900-76aa-11e9-83e3-8e644b04929c.png">
**ERROR**
_before_
<img width="735" alt="before2" src="https://user-images.githubusercontent.com/10623367/57737082-a1a56600-76aa-11e9-9bf5-82293b2ea16a.png">
_after_
<img width="735" alt="after2" src="https://user-images.githubusercontent.com/10623367/57737084-a4a05680-76aa-11e9-9912-17bb99b56d82.png">
