### PR TITLE
Use collapsed console.group

### DIFF
--- a/client.js
+++ b/client.js
@@ -191,8 +191,8 @@ function createReporter() {
     var title = '[HMR] bundle ' + name + 'has ' + obj[type].length + ' ' + type;
     // NOTE: console.warn or console.error will print the stack trace
     // which isn't helpful here, so using console.log to escape it.
-    if (console.group && console.groupEnd) {
-      console.group('%c' + title, style);
+    if (console.groupCollapsed && console.groupEnd) {
+      console.groupCollapsed('%c' + title, style);
       console.log('%c' + newProblems, style);
       console.groupEnd();
     } else {


### PR DESCRIPTION
This PR contains a:

- [x] small change

### Motivation / Use-Case

In my console I get massive warnings, so moving to collapsed would really help. The warnings are unavoidable due to a different typescript/babel/webpack error thats pending resolution.

![image](https://user-images.githubusercontent.com/12100/58196061-406b2d00-7c7e-11e9-9a61-fd0ba7768626.png)

(and so on for 10 pages)

### Breaking Changes

None

### Additional Info
