### PR TITLE
Make "reload" option true by default

### DIFF
--- a/client.js
+++ b/client.js
@@ -5,7 +5,7 @@ var options = {
   path: '/__webpack_hmr',
   timeout: 20 * 1000,
   overlay: true,
-  reload: false,
+  reload: true,
   log: true,
   warn: true,
   name: '',


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

i found [this issue](https://github.com/electron-userland/electron-forge/issues/1164) on Electron Forge Webpack template, i know this PR will fix it in a indirect way, but i believe this is a good choice for future projects that depends on this module

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

when HMR fails (in case of React for example), it should by default do a page reload, unless you [override](https://github.com/webpack-contrib/webpack-hot-middleware#client) the reload option and set it to false.

