### PR TITLE
Fix overlay not showing on Webpack v5

### DIFF
--- a/client-overlay.js
+++ b/client-overlay.js
@@ -40,7 +40,10 @@ var entities = new Entities();
 
 function showProblems(type, lines) {
   clientOverlay.innerHTML = '';
-  lines.forEach(function(msg) {
+  lines.forEach(function(line) {
+    var isNested = typeof line === 'object';
+    var msg = isNested ? line.moduleName + '\n\n' + line.message : line;
+
     msg = ansiHTML(entities.encode(msg));
     var div = document.createElement('div');
     div.style.marginBottom = '26px';

--- a/client.js
+++ b/client.js
@@ -176,8 +176,10 @@ function createReporter() {
   var previousProblems = null;
   function log(type, obj) {
     var newProblems = obj[type]
-      .map(function(msg) {
-        return strip(msg);
+      .map(function(problem) {
+        var isNested = typeof problem === 'object';
+        var message = isNested ? problem.message : problem;
+        return strip(message);
       })
       .join('\n');
     if (previousProblems == newProblems) {

--- a/middleware.js
+++ b/middleware.js
@@ -122,6 +122,7 @@ function publishStats(action, statsResult, eventStream, log) {
     modules: true,
     timings: true,
     hash: true,
+    errors: true,
   });
   // For multi-compiler, stats will be an object with a 'children' array of stats
   var bundles = extractBundles(stats);


### PR DESCRIPTION
Hi!
This PR contains fix for overlay issue in Webpack 5 (#392)
Webpack 5 has a bit different way of handling errors with new error structure, so overlay was not working.
This fix is backward compatible with older Webpack versions (tested with both v4 and v5)

Cheers,
Taras