### PR TITLE
feat: replace querystring with urlsearchparams

### DIFF
--- a/client.js
+++ b/client.js
@@ -15,7 +15,9 @@ var options = {
   ansiColors: {},
 };
 if (__resourceQuery) {
-  var overrides = Object.fromEntries(new URLSearchParams(__resourceQuery.slice(1)));
+  var overrides = Object.fromEntries(
+    new URLSearchParams(__resourceQuery.slice(1))
+  );
   setOverrides(overrides);
 }
 
@@ -24,8 +26,8 @@ if (typeof window === 'undefined') {
 } else if (typeof window.EventSource === 'undefined') {
   console.warn(
     "webpack-hot-middleware's client requires EventSource to work. " +
-    'You should include a polyfill if you want to support this browser: ' +
-    'https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools'
+      'You should include a polyfill if you want to support this browser: ' +
+      'https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools'
   );
 } else {
   if (options.autoConnect) {
@@ -239,8 +241,8 @@ function processMessage(obj) {
       if (options.log) {
         console.log(
           '[HMR] bundle ' +
-          (obj.name ? "'" + obj.name + "' " : '') +
-          'rebuilding'
+            (obj.name ? "'" + obj.name + "' " : '') +
+            'rebuilding'
         );
       }
       break;
@@ -248,10 +250,10 @@ function processMessage(obj) {
       if (options.log) {
         console.log(
           '[HMR] bundle ' +
-          (obj.name ? "'" + obj.name + "' " : '') +
-          'rebuilt in ' +
-          obj.time +
-          'ms'
+            (obj.name ? "'" + obj.name + "' " : '') +
+            'rebuilt in ' +
+            obj.time +
+            'ms'
         );
       }
     // fall through

--- a/client.js
+++ b/client.js
@@ -15,8 +15,7 @@ var options = {
   ansiColors: {},
 };
 if (__resourceQuery) {
-  var querystring = require('querystring');
-  var overrides = querystring.parse(__resourceQuery.slice(1));
+  var overrides = Object.fromEntries(new URLSearchParams(__resourceQuery.slice(1)));
   setOverrides(overrides);
 }
 
@@ -25,8 +24,8 @@ if (typeof window === 'undefined') {
 } else if (typeof window.EventSource === 'undefined') {
   console.warn(
     "webpack-hot-middleware's client requires EventSource to work. " +
-      'You should include a polyfill if you want to support this browser: ' +
-      'https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools'
+    'You should include a polyfill if you want to support this browser: ' +
+    'https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#Tools'
   );
 } else {
   if (options.autoConnect) {
@@ -240,8 +239,8 @@ function processMessage(obj) {
       if (options.log) {
         console.log(
           '[HMR] bundle ' +
-            (obj.name ? "'" + obj.name + "' " : '') +
-            'rebuilding'
+          (obj.name ? "'" + obj.name + "' " : '') +
+          'rebuilding'
         );
       }
       break;
@@ -249,10 +248,10 @@ function processMessage(obj) {
       if (options.log) {
         console.log(
           '[HMR] bundle ' +
-            (obj.name ? "'" + obj.name + "' " : '') +
-            'rebuilt in ' +
-            obj.time +
-            'ms'
+          (obj.name ? "'" + obj.name + "' " : '') +
+          'rebuilt in ' +
+          obj.time +
+          'ms'
         );
       }
     // fall through

--- a/package-lock.json
+++ b/package-lock.json
@@ -4699,7 +4699,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "ansi-html-community": "0.0.8",
     "html-entities": "^2.1.0",
-    "querystring": "^0.2.0",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The querystring API is deprecated

### Breaking Changes

changing the querystring API for the URLSearchParams API could bring breaking changes as the querystring API remove trailing characters from the params and URLSearchParams don't, but in the webpack hot middleware case, this should not be a breaking change, also the URLSearchParams API is not available in node 0.4 and below, that might be a little issue

### Additional Info

![2021-09-05_13-09](https://user-images.githubusercontent.com/65319051/132134139-b729fecc-22ef-46ef-9855-a8f029a466fc.png)
