### PR TITLE
fix: replace ansi-html with ansi-html-community to fix vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Configuration options can be passed to the client by adding querystring paramete
 * **quiet** - Set to `true` to disable all console logging.
 * **dynamicPublicPath** - Set to `true` to use webpack `publicPath` as prefix of `path`. (We can set `__webpack_public_path__` dynamically at runtime in the entry point, see note of [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath))
 * **autoConnect** - Set to `false` to use to prevent a connection being automatically opened from the client to the webpack back-end - ideal if you need to modify the options using the `setOptionsAndConnect` function
-* **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html](https://github.com/Tjatse/ansi-html/blob/99ec49e431c70af6275b3c4e00c7be34be51753c/README.md#set-colors) package.
+* **ansiColors** - An object to customize the client overlay colors as mentioned in the [ansi-html-community](https://github.com/mahdyar/ansi-html-community#set-colors) package.
 * **overlayStyles** - An object to let you override or add new inline styles to the client overlay div.
 * **overlayWarnings** - Set to `true` to enable client overlay on warnings in addition to errors.
 

--- a/client-overlay.js
+++ b/client-overlay.js
@@ -21,7 +21,7 @@ var styles = {
   textAlign: 'left',
 };
 
-var ansiHTML = require('ansi-html');
+var ansiHTML = require('ansi-html-community');
 var colors = {
   reset: ['transparent', 'transparent'],
   black: '181818',

--- a/package-lock.json
+++ b/package-lock.json
@@ -649,8 +649,8 @@
     },
     "ansi-html-community": {
       "version": "0.0.8",
-      "resolved": "https://repository.vnerd.com/artifactory/api/npm/npm-pluralsight/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha1-afvE1sy+OD+XNpNK40w/gpDxv0E="
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="
     },
     "ansi-regex": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -647,10 +647,10 @@
       "integrity": "sha512-hTv1qPdi+sVEk3jYsdjox5nQI0C9HTbjKShbCdYLKb1LOfNbb7wsF4d7OEKIZoxIHx02tSp3m94jcPW2EfMjmA==",
       "dev": true
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://repository.vnerd.com/artifactory/api/npm/npm-pluralsight/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha1-afvE1sy+OD+XNpNK40w/gpDxv0E="
     },
     "ansi-regex": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Glen Mailer <glen@stainlessed.co.uk>",
   "license": "MIT",
   "dependencies": {
-    "ansi-html": "0.0.7",
+    "ansi-html-community": "0.0.8",
     "html-entities": "^2.1.0",
     "querystring": "^0.2.0",
     "strip-ansi": "^6.0.0"


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
This is a fix for the vulnerability reported in [CVE-2021-23424][CVE] by
replacing the ansi-html dependency with a fork of the project that has
the [suggested fix][ansi-html-fix] and resolves [#412][412]

[CVE]: https://nvd.nist.gov/vuln/detail/CVE-2021-23424
[ansi-html-fix]: https://github.com/Tjatse/ansi-html/issues/19
[412]: https://github.com/webpack-contrib/webpack-hot-middleware/issues/412