### PR TITLE
build: Starting with Node 11, Use of the legacy url.parse() method is…

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -2,7 +2,8 @@ var parse = require('url').parse;
 
 exports.pathMatch = function (url, path) {
   try {
-    if (typeof URL === 'function') return new URL(url,'https://localhost/').pathname === path;
+    if (typeof URL === 'function')
+      return new URL(url, 'https://localhost/').pathname === path;
     return parse(url).pathname === path;
   } catch (e) {
     return false;

--- a/helpers.js
+++ b/helpers.js
@@ -2,7 +2,7 @@ var parse = require('url').parse;
 
 exports.pathMatch = function (url, path) {
   try {
-    if (typeof URL === 'function') return new URL(url).pathname === path;
+    if (typeof URL === 'function') return new URL(url,'https://localhost/').pathname === path;
     return parse(url).pathname === path;
   } catch (e) {
     return false;

--- a/helpers.js
+++ b/helpers.js
@@ -2,6 +2,7 @@ var parse = require('url').parse;
 
 exports.pathMatch = function (url, path) {
   try {
+    if (typeof URL === 'function') return new URL(url).pathname === path;
     return parse(url).pathname === path;
   } catch (e) {
     return false;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Starting with Node 11, Use of the legacy url.parse() method is discouraged. Users should use the WHATWG URL API. Because the url.parse() method  uses a lenient, non-standard algorithm for parsing URL strings, security issues can be introduced.So I tried to make compatibility changes.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
None