### PR TITLE
Only test against LTS for now, as webpack 4 doesn't work on node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              node_version: [lts, current]
+              node_version: [lts]
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Webpack 4 and Node 17+ don't mix - see https://github.com/webpack/webpack/issues/14532 for details

For now we'll just only test against node 16.

### Breaking Changes

none

### Additional Info
