### PR TITLE
feat: improve logic for handling multicomplier stats result to accomodate webpack5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,4 @@ jobs:
     working_directory: /mnt/ramdisk
     steps:
       - setup
-      - run: npm test
+      - run: NODE_OPTIONS=--openssl-legacy-provider npm test

--- a/test/fixtures/multi-compiler/.gitignore
+++ b/test/fixtures/multi-compiler/.gitignore
@@ -1,0 +1,1 @@
+*-compilation-client.js

--- a/test/realistic-test.js
+++ b/test/realistic-test.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 var path = require('path');
+var qs = require('querystring');
 
 var express = require('express');
 var webpack = require('webpack');
@@ -10,9 +11,10 @@ var supertest = require('supertest');
 
 var webpackHotMiddleware = require('../middleware');
 
-var app, compiler;
+var app;
 
 describe('realistic single compiler', function () {
+  var compiler;
   var clientCode = path.resolve(__dirname, './fixtures/single/client.js');
   before(function () {
     require('fs').writeFileSync(clientCode, 'var a = ' + Math.random() + ';\n');
@@ -113,6 +115,171 @@ describe('realistic single compiler', function () {
           assert.ok(Array.isArray(event.warnings));
           assert.ok(Array.isArray(event.errors));
           assert.ok(typeof event.modules === 'object');
+
+          done();
+        }
+      );
+    });
+  });
+});
+
+describe('realistic multi compiler', function () {
+  var multiCompiler;
+
+  var compilationConfig = [
+    {
+      name: 'first',
+      entryPath: path.join(
+        __dirname,
+        './fixtures/multi-compiler/first-compilation-client.js'
+      ),
+    },
+    {
+      name: 'second',
+      entryPath: path.join(
+        __dirname,
+        './fixtures/multi-compiler/second-compilation-client.js'
+      ),
+    },
+  ];
+
+  before(function () {
+    multiCompiler = webpack(
+      compilationConfig.map(function (compilation) {
+        require('fs').writeFileSync(
+          compilation.entryPath,
+          'var a = ' + Math.random() + ';\n'
+        );
+
+        return {
+          name: compilation.name,
+          mode: 'development',
+          entry: [
+            require.resolve(compilation.entryPath),
+            path.join(
+              __dirname,
+              '../client.js' +
+                '?=' +
+                qs.stringify({
+                  name: compilation.name,
+                })
+            ),
+          ],
+          plugins: [new webpack.HotModuleReplacementPlugin()],
+        };
+      })
+    );
+
+    app = express();
+    app.use(
+      webpackDevMiddleware(multiCompiler, {
+        publicPath: '/',
+        logLevel: 'silent',
+      })
+    );
+    app.use(
+      webpackHotMiddleware(multiCompiler, {
+        log: function () {},
+      })
+    );
+  });
+
+  it('should create eventStream on /__webpack_hmr', function (done) {
+    request('/__webpack_hmr')
+      .expect('Content-Type', /^text\/event-stream\b/)
+      .end(done);
+  });
+
+  describe('first build', function () {
+    it('should publish sync event for all compilations from multi compiler', function (done) {
+      request('/__webpack_hmr')
+        .expect('Content-Type', /^text\/event-stream\b/)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          assert.equal(res.events.length, compilationConfig.length);
+
+          res.events.forEach(function (resEvent, idx) {
+            var event = JSON.parse(resEvent.substring(5));
+            assert.equal(event.action, 'sync');
+            assert.equal(event.name, compilationConfig[idx].name);
+            assert.ok(event.hash);
+            assert.ok(event.time);
+            assert.ok(Array.isArray(event.warnings));
+            assert.ok(Array.isArray(event.errors));
+            assert.ok(typeof event.modules === 'object');
+          });
+
+          done();
+        });
+    });
+  });
+
+  describe('after file change', function () {
+    var res;
+
+    before(function (done) {
+      request('/__webpack_hmr')
+        .expect('Content-Type', /^text\/event-stream\b/)
+        .end(function (err, _res) {
+          if (err) return done(err);
+
+          res = _res;
+
+          // simulate write to a random entry of the compilation config list
+          require('fs').writeFile(
+            compilationConfig[
+              Math.floor(Math.random() * compilationConfig.length)
+            ].entryPath,
+            'var a = ' + Math.random() + ';\n',
+            done
+          );
+        });
+    });
+
+    it('should publish building event', function (done) {
+      waitUntil(
+        function () {
+          // building phase is after sync phase, but because we only change one file
+          // we expect compilationConfig length + 1 events
+          return res.events.length >= compilationConfig.length + 1;
+        },
+        function () {
+          var phaseEvents = res.events.slice(compilationConfig.length);
+
+          phaseEvents.forEach(function (phaseEvent) {
+            var event = JSON.parse(phaseEvent.substring(5));
+
+            assert.equal(event.action, 'building');
+          });
+
+          done();
+        }
+      );
+    });
+
+    it('should publish built event', function (done) {
+      waitUntil(
+        function () {
+          // built is 3rd phase, right after building
+          // we expect to have received 2 batches of events for all entries of the compilationConfig
+          // in addition to the single event fired for our simulated write
+          return res.events.length >= 2 * compilationConfig.length + 1;
+        },
+        function () {
+          var phaseEvents = res.events.slice(compilationConfig.length + 1);
+
+          phaseEvents.forEach(function (phaseEvent, idx) {
+            var event = JSON.parse(phaseEvent.substring(5));
+
+            assert.equal(event.action, 'built');
+            assert.equal(event.name, compilationConfig[idx].name);
+            assert.ok(event.hash);
+            assert.ok(event.time);
+            assert.ok(Array.isArray(event.warnings));
+            assert.ok(Array.isArray(event.errors));
+            assert.ok(typeof event.modules === 'object');
+          });
 
           done();
         }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

This PR aims to address an issue I think is related to #390, 

Details of my system setup;
 
- Operating System: Mac
- Node Version: v16.18.0
- NPM Version: 8.19.2
- Yarn Version: 1.22.17
- webpack Version: ^5.7.3
- ${package} Version: 2.25.2

I had a similar issue on further investigation, I realized that the problem happens because the shape of stats object returned in Webpack 5 differs from that of Webpack 4. [See here](https://github.com/webpack/webpack/blob/main/lib/MultiCompiler.js#L97). 

This PR checks the returned stats object for the `stats` property on the returned `statsResult` which also present on multicomplier stats results generated from Webpack, the returned stats is handled as such if this is the case, from there on everything works like it should.
 
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
