### PR TITLE
Replace usage of `Object.fromEntries` with `reduce`

### DIFF
--- a/client.js
+++ b/client.js
@@ -15,9 +15,12 @@ var options = {
   ansiColors: {},
 };
 if (__resourceQuery) {
-  var overrides = Object.fromEntries(
-    new URLSearchParams(__resourceQuery.slice(1))
-  );
+  var params = Array.from(new URLSearchParams(__resourceQuery.slice(1)));
+  var overrides = params.reduce(function (memo, param) {
+    memo[param[0]] = param[1];
+    return memo;
+  }, {});
+
   setOverrides(overrides);
 }
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Occasionally I need to test on legacy browsers. `webpack-hot-middleware` has pretty good support for older browsers but I've spotted a case where it could broaden its support. Replacing `Object.fromEntries` with `reduce` should bring back support for Chrome 49-72, Safari 10.1-12.0 and Firefox 44-62 (based upon comparing caniuse tables for [`Object.fromEntries`](https://caniuse.com/mdn-javascript_builtins_object_fromentries) and [`UrlSearchParams`](https://caniuse.com/urlsearchparams)), assuming that "browsers that support `UrlSearchParams`" is the bottom boundary.

