### PR TITLE
Add fallbacks to `moduleName` and `loc` webpack 5 error fields if not present in middleware's error formatter

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -193,7 +193,9 @@ function formatErrors(errors) {
 
   // Convert webpack@5 error info into a backwards-compatible flat string
   return errors.map(function (error) {
-    return error.moduleName + ' ' + error.loc + '\n' + error.message;
+    var moduleName = error.moduleName || '';
+    var loc = error.loc || '';
+    return moduleName + ' ' + loc + '\n' + error.message;
   });
 }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Solves 'moduleName' and 'loc' converted to string `undefined` if not present in middleware's error formatter (for webpack 5 errors)

### Breaking Changes
No breaking changes introduced

### Additional Info
[Related issue ticket](https://github.com/webpack-contrib/webpack-hot-middleware/issues/446)