### PR TITLE
Allow specifying EventStream

### DIFF
--- a/client.js
+++ b/client.js
@@ -241,6 +241,9 @@ var subscribeAllHandler;
 function processMessage(obj) {
   switch (obj.action) {
     case 'building':
+      if (obj.name && options.name && obj.name !== options.name) {
+        return;
+      }
       if (options.log) {
         console.log(
           '[HMR] bundle ' +
@@ -250,6 +253,9 @@ function processMessage(obj) {
       }
       break;
     case 'built':
+      if (obj.name && options.name && obj.name !== options.name) {
+          return;
+      }
       if (options.log) {
         console.log(
           '[HMR] bundle ' +

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,5 @@
 module.exports = webpackHotMiddleware;
+module.exports.createEventStream = createEventStream;
 
 var helpers = require('./helpers');
 var pathMatch = helpers.pathMatch;
@@ -12,7 +13,7 @@ function webpackHotMiddleware(compiler, opts) {
   opts.statsOptions =
     typeof opts.statsOptions == 'undefined' ? {} : opts.statsOptions;
 
-  var eventStream = createEventStream(opts.heartbeat);
+  var eventStream = opts.eventStream || createEventStream(opts.heartbeat);
   var latestStats = null;
   var closed = false;
 
@@ -27,7 +28,7 @@ function webpackHotMiddleware(compiler, opts) {
     if (closed) return;
     latestStats = null;
     if (opts.log) opts.log('webpack building...');
-    eventStream.publish({ action: 'building' });
+    eventStream.publish({ action: 'building', name: compiler.name });
   }
   function onDone(statsResult) {
     if (closed) return;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -377,6 +377,7 @@ describe('client', function () {
           close: sinon.spy(),
         }),
       };
+      s.stub(console, 'log');
     });
     beforeEach(loadClient);
     it('should not trigger webpack if event obj name is different', function () {
@@ -408,6 +409,26 @@ describe('client', function () {
         })
       );
       sinon.assert.notCalled(processUpdate);
+    });
+    it('should not log building if obj name is different', function () {
+      var eventSource = window.EventSource.lastCall.returnValue;
+      eventSource.onmessage(
+        makeMessage({
+          name: 'bar',
+          action: 'building',
+        })
+      );
+      sinon.assert.notCalled(console.log);
+    });
+    it('should not log built if obj name is different', function () {
+      var eventSource = window.EventSource.lastCall.returnValue;
+      eventSource.onmessage(
+        makeMessage({
+          name: 'bar',
+          action: 'built',
+        })
+      );
+      sinon.assert.notCalled(console.log);
     });
   });
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [X] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
We have several bundles built using module federation and want to run dev servers for all of them in parallel. Currently this requires opening 1 event stream per bundle, which causes problems because Chrome limits open requests to a single domain to 6. This PR fixes that issue by exporting `createEventStream` and adding an `eventStream` to the middlware options, so we can create a single event stream and share it between all of our webpack instances.