### PR TITLE
docs: fix "occurrence" spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Next, enable hot reloading in your webpack config:
     ]
     ```
 
-    Occurence ensures consistent build hashes, hot module replacement is
+    Occurrence ensures consistent build hashes, hot module replacement is
     somewhat self-explanatory, no errors is used to handle errors more cleanly.
 
  3. Add `'webpack-hot-middleware/client'` into an array of the `entry` 


### PR DESCRIPTION
## Description
Fixed a typo where "occurrence" was misspelled in the webpack configuration documentation section.

## Changes Made
- Corrected spelling from "occurence" to "occurrence" in README.md

## Related Issue
Fixes #318 

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have reviewed my own code
- [x] I have updated the documentation accordingly
